### PR TITLE
Renaming iOS Project in setup file.

### DIFF
--- a/.github/workflows/template_change_test.yml
+++ b/.github/workflows/template_change_test.yml
@@ -51,5 +51,17 @@ jobs:
         run: ./gradlew clean
 
       # Only build enough to verify compilation: https://touchlab.co/touchlab-build-only-what-you-need#ci
-      - name: Build
-        run: ./gradlew assembleDebug linkDebugFrameworkIosSimulatorArm64
+      - name: Android Build
+        run: ./gradlew assembleDebug
+
+      - name: IOS Build
+        uses: sersoft-gmbh/xcodebuild-action@v3
+        with:
+          project: iosApp/myIOS.xcodeproj
+          scheme: myIOS
+          destination: name=iPhone 8
+          sdk: iphoneos
+          configuration: Debug
+          action: build
+          use-xcpretty: false
+          build-settings: CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO

--- a/buildscripts/setup.gradle
+++ b/buildscripts/setup.gradle
@@ -372,7 +372,7 @@ task keepOrRemoveDependencies {
     }
 }
 
-task renameIOSUITest(type: Copy) {
+task renameIOSUITests(type: Copy) {
     description "Renames the IOSUITests directory."
     group null
 
@@ -398,14 +398,94 @@ task renameIOSUITest(type: Copy) {
     }
 }
 
-task renameiOSApp {
+task renameIOSTests(type: Copy) {
+    description "Renames the IOSTests directory."
+    group null
+
+    def startingDirectory = "${rootDir}/iosApp/${renameConfig.templateIOSName}Tests"
+    def endingDirectory = "${rootDir}/iosApp/${renameConfig.newIOSName}Tests"
+
+    from(startingDirectory)
+    into(endingDirectory)
+
+    filter { line ->
+        line.replaceAll(
+                renameConfig.templateIOSName,
+                renameConfig.newIOSName
+        )
+    }
+
+    rename { filename ->
+        filename.replace renameConfig.templateIOSName, renameConfig.newIOSName
+    }
+
+    doLast {
+        delete(startingDirectory)
+    }
+}
+
+task renameIOSFolder(type: Copy) {
+    description "Renames the IOS Content folder."
+    group null
+
+    def startingDirectory = "${rootDir}/iosApp/${renameConfig.templateIOSName}"
+    def endingDirectory = "${rootDir}/iosApp/${renameConfig.newIOSName}"
+
+    from(startingDirectory)
+    into(endingDirectory)
+
+    filter { line ->
+        line.replaceAll(
+                renameConfig.templateIOSName,
+                renameConfig.newIOSName
+        )
+    }
+
+    rename { filename ->
+        filename.replace renameConfig.templateIOSName, renameConfig.newIOSName
+    }
+
+    doLast {
+        delete(startingDirectory)
+    }
+}
+
+task renameXcodeproject(type: Copy) {
+    description "Renames the IOS xcodeproject folder."
+    group null
+
+    def startingDirectory = "${rootDir}/iosApp/${renameConfig.templateIOSName}.xcodeproj"
+    def endingDirectory = "${rootDir}/iosApp/${renameConfig.newIOSName}.xcodeproj"
+
+    from(startingDirectory)
+    into(endingDirectory)
+
+    filter { line ->
+        line.replaceAll(
+                renameConfig.templateIOSName,
+                renameConfig.newIOSName
+        )
+    }
+
+    rename { filename ->
+        filename.replace renameConfig.templateIOSName, renameConfig.newIOSName
+    }
+
+    doLast {
+        delete(startingDirectory)
+    }
+}
+
+task renameIOSApp {
     description "Rename the iOS application based on the renameConfig."
     group "Template Setup"
 
-    // TODO: Rename templateIOSUITests package and files
-    // TODO: Rename templateIOSTests package and files
-    // TODO: Rename templateIOS package and files
-    // TODO: Rename templateIOS.xcodeproj package and files
+    dependsOn(
+            renameIOSUITests,
+            renameIOSTests,
+            renameIOSFolder,
+            renameXcodeproject,
+    )
 }
 
 task renameTemplate {
@@ -419,6 +499,7 @@ task renameTemplate {
             renameSharedIOSPackage,
             renameSharedCommonPackage,
             replaceTemplateReferences,
+            renameIOSApp,
             deleteSetupCode,
     )
 

--- a/buildscripts/setup.gradle
+++ b/buildscripts/setup.gradle
@@ -376,8 +376,8 @@ task renameIOSUITest(type: Copy) {
     description "Renames the IOSUITests directory."
     group null
 
-    def startingDirectory = "${rootDir}/${renameConfig.templateIOSName}UITests"
-    def endingDirectory = "${rootDir}/${renameConfig.newIOSName}UITests"
+    def startingDirectory = "${rootDir}/iosApp/${renameConfig.templateIOSName}UITests"
+    def endingDirectory = "${rootDir}/iosApp/${renameConfig.newIOSName}UITests"
 
     from(startingDirectory)
     into(endingDirectory)
@@ -391,6 +391,10 @@ task renameIOSUITest(type: Copy) {
 
     rename { filename ->
         filename.replace renameConfig.templateIOSName, renameConfig.newIOSName
+    }
+
+    doLast {
+        delete(startingDirectory)
     }
 }
 

--- a/buildscripts/setup.gradle
+++ b/buildscripts/setup.gradle
@@ -3,10 +3,12 @@ def renameConfig = [
         templateAppId               : "template.app.id",
         templateMaterialThemeName   : "TemplateTheme",
         templateApplicationClassName: "TemplateApp",
+        templateIOSName             : "templateIOS",
         newPackage                  : "domain.yourname.app",
         newProjectName              : "Your Project",
         newMaterialThemeName        : "MyMaterialTheme",
         newApplicationClassName     : "MyApp",
+        newIOSName                  : "myIOS",
         useHiltDependencies         : true,
         useRoomDependencies         : true,
         useRetrofitDependencies     : true,
@@ -368,6 +370,38 @@ task keepOrRemoveDependencies {
             }
         }
     }
+}
+
+task renameIOSUITest(type: Copy) {
+    description "Renames the IOSUITests directory."
+    group null
+
+    def startingDirectory = "${rootDir}/${renameConfig.templateIOSName}UITests"
+    def endingDirectory = "${rootDir}/${renameConfig.newIOSName}UITests"
+
+    from(startingDirectory)
+    into(endingDirectory)
+
+    filter { line ->
+        line.replaceAll(
+                renameConfig.templateIOSName,
+                renameConfig.newIOSName
+        )
+    }
+
+    rename { filename ->
+        filename.replace renameConfig.templateIOSName, renameConfig.newIOSName
+    }
+}
+
+task renameiOSApp {
+    description "Rename the iOS application based on the renameConfig."
+    group "Template Setup"
+
+    // TODO: Rename templateIOSUITests package and files
+    // TODO: Rename templateIOSTests package and files
+    // TODO: Rename templateIOS package and files
+    // TODO: Rename templateIOS.xcodeproj package and files
 }
 
 task renameTemplate {


### PR DESCRIPTION
## Summary

<!--Provide a summary of this Pull Request. -->

Fixes #9 by supporting renaming the iOS project as well. 

## How It Was Tested

<!-- Explain how you tested this change before merging. -->

Ran locally and verified I could open `myIOS` and see the project in a simulator. CI passing is also crucial here.
