### PR TITLE
Moving paparazzi plugin to shared module

### DIFF
--- a/.github/workflows/template_change_test.yml
+++ b/.github/workflows/template_change_test.yml
@@ -53,3 +53,6 @@ jobs:
           action: build
           use-xcpretty: false
           build-settings: CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO
+
+      - name: Run Tests
+        run: ./gradlew test

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,4 @@
 plugins {
-    id("app.cash.paparazzi")
     id("com.android.application")
     id("com.google.devtools.ksp")
     id("kotlin-android")

--- a/buildscripts/setup.gradle
+++ b/buildscripts/setup.gradle
@@ -276,6 +276,47 @@ task renameSharedCommonPackage(type: Copy) {
     }
 }
 
+task renameSharedTestPackage(type: Copy) {
+    description "Renames the template package in the shared/test module."
+    group null
+
+    def newPackageAsDirectory = renameConfig.newPackage.replaceAll("\\.", "/")
+    def startingDirectory = "${rootDir}/shared/src/test/kotlin/${renameConfig.templateName}/shared"
+    def endingDirectory = "${rootDir}/shared/src/test/kotlin/${newPackageAsDirectory}/shared"
+
+    from(startingDirectory)
+    into(endingDirectory)
+
+    // Replace package statements
+    filter { line ->
+        line.replaceAll(
+                "package ${renameConfig.templateName}",
+                "package ${renameConfig.newPackage}"
+        )
+    }
+
+    // Replace import statements
+    filter { line ->
+        line.replaceAll(
+                "import ${renameConfig.templateName}",
+                "import ${renameConfig.newPackage}"
+        )
+    }
+
+    // Replace Theme references. We can just replace on name,
+    // which covers both imports and function calls.
+    filter { line ->
+        line.replaceAll(
+                "${renameConfig.templateMaterialThemeName}",
+                "${renameConfig.newMaterialThemeName}"
+        )
+    }
+
+    doLast {
+        delete(startingDirectory)
+    }
+}
+
 task replaceTemplateReferences {
     description "Replaces references to template in various files."
     group null
@@ -481,6 +522,7 @@ task renameTemplate {
             renameSharedAndroidPackage,
             renameSharedIOSPackage,
             renameSharedCommonPackage,
+            renameSharedTestPackage,
             replaceTemplateReferences,
             renameIOSApp,
             deleteSetupCode,

--- a/buildscripts/setup.gradle
+++ b/buildscripts/setup.gradle
@@ -348,6 +348,8 @@ task keepOrRemoveDependencies {
             if (renameConfig.usePaparazziDependencies != true) {
                 println("Removing paparazzi dependencies")
                 removeTextFromFile(fileName, "paparazzi")
+
+                delete("${rootDir}/shared/src/test/kotlin/template/shared/PaparazziUtils.kt")
             }
         }
     }

--- a/buildscripts/setup.gradle
+++ b/buildscripts/setup.gradle
@@ -339,6 +339,7 @@ task keepOrRemoveDependencies {
         def filesWithDependencies = [
                 "${rootDir}/build.gradle.kts",
                 "${rootDir}/app/build.gradle.kts",
+                "${rootDir}/shared/build.gradle.kts",
                 "${rootDir}/gradle/libs.versions.toml",
                 "${rootDir}/app/src/main/java/template/TemplateApp.kt",
         ]

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("multiplatform")
+    id("app.cash.paparazzi")
     id("com.android.library")
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.kotlin.compose)
@@ -37,6 +38,10 @@ kotlin {
             implementation(compose.components.uiToolingPreview)
             implementation(libs.androidx.lifecycle.viewmodel)
             implementation(libs.androidx.lifecycle.runtime.compose)
+        }
+
+        commonTest.dependencies {
+            implementation(kotlin("test"))
         }
     }
 }

--- a/shared/src/test/kotlin/template/shared/PaparazziUtils.kt
+++ b/shared/src/test/kotlin/template/shared/PaparazziUtils.kt
@@ -3,32 +3,37 @@ package template.shared
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Surface
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import app.cash.paparazzi.Paparazzi
+import template.shared.theme.TemplateTheme
 
 /**
  * This is a helper function that renders all of our content inside a box that takes up max space,
  * and also wraps it around our design system theme.
  */
 fun Paparazzi.snapshotScreen(
-    useDarkTheme: Boolean,
+    darkTheme: Boolean,
     screenPaddingDp: Int = 16,
     content: @Composable () -> Unit,
 ) {
     this.snapshot {
-        Surface(
-            modifier = Modifier
-                .fillMaxSize(),
+        TemplateTheme(
+            darkTheme = darkTheme,
         ) {
-            Box(
+            Surface(
                 modifier = Modifier
-                    .fillMaxSize()
-                    .padding(screenPaddingDp.dp),
+                    .fillMaxSize(),
             ) {
-                content()
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(screenPaddingDp.dp),
+                ) {
+                    content()
+                }
             }
         }
     }

--- a/shared/src/test/kotlin/template/shared/PaparazziUtils.kt
+++ b/shared/src/test/kotlin/template/shared/PaparazziUtils.kt
@@ -1,0 +1,35 @@
+package template.shared
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import app.cash.paparazzi.Paparazzi
+
+/**
+ * This is a helper function that renders all of our content inside a box that takes up max space,
+ * and also wraps it around our design system theme.
+ */
+fun Paparazzi.snapshotScreen(
+    useDarkTheme: Boolean,
+    screenPaddingDp: Int = 16,
+    content: @Composable () -> Unit,
+) {
+    this.snapshot {
+        Surface(
+            modifier = Modifier
+                .fillMaxSize(),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(screenPaddingDp.dp),
+            ) {
+                content()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

<!--Provide a summary of this Pull Request. -->

Sets up the template to easily use paparazzi to snapshot Compose components in shared module. 

## How It Was Tested

<!-- Explain how you tested this change before merging. -->

CI passing is enough on this one, since paparazzi is unused. Need to make sure template change passes though. 
