### PR TITLE
Adding formatting to rename flow

### DIFF
--- a/buildscripts/setup.gradle
+++ b/buildscripts/setup.gradle
@@ -645,7 +645,6 @@ task renameTemplate {
             renameSharedGraphqlDirectory,
             replaceTemplateReferences,
             renameIOSApp,
-            formatKotlin,
             deleteSetupCode,
     )
 
@@ -653,6 +652,7 @@ task renameTemplate {
         exec {
             // After all setup changes happen, run a `git add` so
             // folks can just immediately commit and push if they wish.
+            commandLine "./gradlew", "formatKotlin"
             commandLine "git", "add", "${rootDir}/."
         }
     }

--- a/buildscripts/setup.gradle
+++ b/buildscripts/setup.gradle
@@ -645,6 +645,7 @@ task renameTemplate {
             renameSharedGraphqlDirectory,
             replaceTemplateReferences,
             renameIOSApp,
+            formatKotlin,
             deleteSetupCode,
     )
 

--- a/buildscripts/setup.gradle
+++ b/buildscripts/setup.gradle
@@ -650,9 +650,12 @@ task renameTemplate {
 
     doLast {
         exec {
+            // Format code after template changes, this matters because ktlint expects
+            // alphabetical imports.
+            commandLine "./gradlew", "formatKotlin"
+
             // After all setup changes happen, run a `git add` so
             // folks can just immediately commit and push if they wish.
-            commandLine "./gradlew", "formatKotlin"
             commandLine "git", "add", "${rootDir}/."
         }
     }


### PR DESCRIPTION
## Summary

<!--Provide a summary of this Pull Request. -->

Depending on the naming convention chosen from the rename, imports can get out of alphabetical order, so we should run a `formatKotlin` at the end to make sure we're all good. 
