### PR TITLE
Using task types to exclude build folders from formatting.

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.jmailen.gradle.kotlinter.tasks.FormatTask
+import org.jmailen.gradle.kotlinter.tasks.LintTask
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.compose.compiler)
@@ -76,10 +79,10 @@ dependencies {
     androidTestImplementation(libs.compose.ui.test.junit)
 }
 
-tasks.formatKotlinMain {
+tasks.withType<FormatTask> {
     exclude { it.file.path.contains("build/")}
 }
 
-tasks.lintKotlinMain {
+tasks.withType<LintTask> {
     exclude { it.file.path.contains("build/")}
 }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,5 +1,7 @@
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jmailen.gradle.kotlinter.tasks.FormatTask
+import org.jmailen.gradle.kotlinter.tasks.LintTask
 
 plugins {
     alias(libs.plugins.android.library)
@@ -111,10 +113,10 @@ apollo {
     }
 }
 
-tasks.formatKotlinCommonMain {
+tasks.withType<FormatTask> {
     exclude { it.file.path.contains("build/")}
 }
 
-tasks.lintKotlinCommonMain {
+tasks.withType<LintTask> {
     exclude { it.file.path.contains("build/")}
 }


### PR DESCRIPTION
## Summary

<!--Provide a summary of this Pull Request. -->

This is a little more fool proof as it's all formatting and linting tasks, not just the commonMain ones. 

## How It Was Tested

<!-- Explain how you tested this change before merging. -->

CI passing should be good, I also used this in another project to verify. 
