### PR TITLE
Adding ImageWrapper component.

### DIFF
--- a/.github/workflows/template_change_test.yml
+++ b/.github/workflows/template_change_test.yml
@@ -42,10 +42,6 @@ jobs:
         run: |
           sed -i '' 's/useApollo.* : true/useApollo : ${{ matrix.keepCustomizableDependencies }}/g' buildscripts/setup.gradle
 
-      - name: Set useCoil
-        run: |
-          sed -i '' 's/useCoil.* : true/useCoil : ${{ matrix.keepCustomizableDependencies }}/g' buildscripts/setup.gradle
-
       - name: Set useRenovate
         run: |
           sed -i '' 's/useRenovate.* : true/useRenovate : ${{ matrix.keepCustomizableDependencies }}/g' buildscripts/setup.gradle

--- a/buildscripts/setup.gradle
+++ b/buildscripts/setup.gradle
@@ -17,7 +17,6 @@ def renameConfig = [
         useKtor                     : true,
         useKoin                     : true,
         useApollo                   : true,
-        useCoil                     : true,
 ]
 
 task renameIOSProject(type: Copy) {
@@ -310,11 +309,6 @@ static def keepOrRemoveDependencies(project, renameConfig) {
             removeTextFromFile(fileName, "apollo")
 
             project.delete("$rootDir/shared/src/commonMain/graphql")
-        }
-
-        if (renameConfig.useCoil != true) {
-            println("Removing coil dependencies")
-            removeTextFromFile(fileName, "coil")
         }
     }
 }

--- a/shared/src/commonMain/kotlin/template/shared/App.kt
+++ b/shared/src/commonMain/kotlin/template/shared/App.kt
@@ -1,7 +1,6 @@
 package template.shared
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.Button
@@ -14,8 +13,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import template.shared.ui.UiImage
+import template.shared.ui.components.ImageWrapper
 import template.shared.ui.theme.TemplateTheme
 
 @Preview
@@ -51,8 +51,8 @@ fun App() {
                         modifier = Modifier
                             .fillMaxWidth(),
                     ) {
-                        Image(
-                            painter = painterResource(Res.drawable.compose_multiplatform),
+                        ImageWrapper(
+                            image = UiImage.Local(Res.drawable.compose_multiplatform),
                             contentDescription = null,
                         )
                         Text(

--- a/shared/src/commonMain/kotlin/template/shared/ui/UiImage.kt
+++ b/shared/src/commonMain/kotlin/template/shared/ui/UiImage.kt
@@ -1,0 +1,23 @@
+package template.shared.ui
+
+import org.jetbrains.compose.resources.DrawableResource
+
+/**
+ * Defines all variations of an image that can be rendered to a user.
+ */
+sealed interface UiImage {
+    /**
+     * Represents an image requested from a network [url].
+     */
+    data class Remote(
+        val url: String,
+    ) : UiImage
+
+    /**
+     * Represents a local image bundled with the app,
+     * identified by [resource].
+     */
+    data class Local(
+        val resource: DrawableResource,
+    ) : UiImage
+}

--- a/shared/src/commonMain/kotlin/template/shared/ui/components/ImageWrapper.kt
+++ b/shared/src/commonMain/kotlin/template/shared/ui/components/ImageWrapper.kt
@@ -1,0 +1,70 @@
+package template.shared.ui.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import coil3.compose.AsyncImage
+import org.jetbrains.compose.resources.painterResource
+import template.shared.ui.UiImage
+
+/**
+ * Wrapper around an [image] that will render the correct component
+ * based on the image type.
+ */
+@Composable
+fun ImageWrapper(
+    image: UiImage,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    contentScale: ContentScale = ContentScale.Fit,
+) {
+    when (image) {
+        is UiImage.Local -> {
+            LocalImage(
+                image = image,
+                contentDescription = contentDescription,
+                contentScale = contentScale,
+                modifier = modifier,
+            )
+        }
+        is UiImage.Remote -> {
+            RemoteImage(
+                image = image,
+                contentDescription = contentDescription,
+                contentScale = contentScale,
+                modifier = modifier,
+            )
+        }
+    }
+}
+
+@Composable
+private fun RemoteImage(
+    image: UiImage.Remote,
+    contentDescription: String?,
+    contentScale: ContentScale,
+    modifier: Modifier,
+) {
+    AsyncImage(
+        model = image.url,
+        contentDescription = contentDescription,
+        contentScale = contentScale,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun LocalImage(
+    image: UiImage.Local,
+    contentDescription: String?,
+    contentScale: ContentScale,
+    modifier: Modifier,
+) {
+    Image(
+        painter = painterResource(image.resource),
+        contentDescription = contentDescription,
+        contentScale = contentScale,
+        modifier = modifier,
+    )
+}


### PR DESCRIPTION
## Summary

<!--Provide a summary of this Pull Request. -->

This makes it easy to support both local and remote images with a single type, making it easy to preview/snapshot stuff as well as render in production.

## How It Was Tested

<!-- Explain how you tested this change before merging. -->

Updated the sample code to use this. 
